### PR TITLE
Fixed critical bug where selecting a prompt opened multiple windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the "PromptVault" extension will be documented in this file.
 
+## [1.2.2] - 2025-11-22
+
+### 🐛 Bug Fixes
+- **Multiple Windows Issue**: Fixed critical bug where selecting a prompt from the tree view opened multiple windows instead of just one
+- **Event Handler Cleanup**: Removed duplicate event handling that caused the same prompt to open twice simultaneously
+- **Tree View Behavior**: Improved tree view selection behavior to be more predictable and responsive
+
+### Technical
+- **Event Architecture**: Centralized prompt opening logic to use only the selection listener, removing redundant command properties from tree items
+- **Code Cleanup**: Simplified tree item creation by removing unnecessary command properties that were causing duplicate calls
+- **Performance**: Reduced overhead by eliminating duplicate event processing when selecting prompts
+
 ## [1.2.1] - 2025-09-27
 
 ### 🐛 Critical Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "promptvault",
   "displayName": "PromptVault Manager",
   "description": "Personal Prompt Manager for managing and organizing prompts locally with AI-powered suggestions",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "publisher": "pankajads",
   "license": "MIT",
   "repository": {

--- a/src/promptTreeProvider.ts
+++ b/src/promptTreeProvider.ts
@@ -94,11 +94,7 @@ export class PromptTreeProvider implements vscode.TreeDataProvider<PromptTreeIte
                 'prompt',
                 tagName, // Pass the parent tag name
                 prompt.id,
-                {
-                    command: 'promptvault.openPrompt',
-                    title: 'Open Prompt',
-                    arguments: [prompt.id]
-                },
+                undefined, // Remove the command property to prevent duplicate calls
                 prompt
             ));
         } catch (error) {


### PR DESCRIPTION
Release v1.2.2: Fix multiple windows bug on prompt selection

- Fixed critical bug where selecting a prompt opened multiple windows
- Removed duplicate event handling in tree view selection
- Centralized prompt opening logic to prevent duplicate calls
- Cleaned up tree item command properties causing redundant execution
- Updated changelog and version to 1.2.2